### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/assets/js/book-config.js
+++ b/assets/js/book-config.js
@@ -18,7 +18,7 @@ mergeObjectsRecursive(BookConfig, window.Book);
 
 function mergeObjectsRecursive(target, source) {
     for (const key in source) {
-        if (source.hasOwnProperty(key)) {
+        if (source.hasOwnProperty(key) && key !== '__proto__' && key !== 'constructor') {
             if (source[key] instanceof Object) {
                 if (!target[key]) {
                     // If the key doesn't exist in the target, create a new object


### PR DESCRIPTION
Potential fix for [https://github.com/veillette/physics-book/security/code-scanning/1](https://github.com/veillette/physics-book/security/code-scanning/1)

To fix the problem, we need to ensure that the `mergeObjectsRecursive` function does not allow prototype pollution. This can be achieved by blocking the `__proto__` and `constructor` properties from being merged or assigned to. We will modify the function to skip these properties during the merge process.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
