### PR TITLE
Remove polyfill.io and upgrade FontAwesome to v6.5.1

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -31,7 +31,6 @@
 
     <script src="{{'/assets/js/math-config.js'| relative_url }}"
             type="text/javascript"></script>
-    <script defer src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?version=4.8.0&features=es6"></script>
     <script async defer id="MathJax-script"
             src="https://cdn.jsdelivr.net/npm/mathjax@4/es5/tex-chtml.js"></script>
 

--- a/assets/js/book-config.js
+++ b/assets/js/book-config.js
@@ -9,7 +9,7 @@ export const BookConfig = {
     serverAddsTrailingSlash: false, //# Used because jekyll adds trailing slashes
     rootUrl: '',
     includes: {
-        fontawesome: 'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css',
+        fontawesome: 'https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css',
     }
 }
 

--- a/assets/js/book-viewer.js
+++ b/assets/js/book-viewer.js
@@ -13,9 +13,9 @@ const BOOK_TEMPLATE =
     `<div class="book with-summary font-size-2 font-family-1">
             <div class="book-header">
                 <a href="#" class="btn pull-left toggle-summary" aria-label="Toggle summary">
-                <i class="fa fa-align-justify"></i></a>
+                <i class="fa-solid fa-bars"></i></a>
                 <h1>
-                <i class="fa fa-spinner fa-spin book-spinner"></i>
+                <i class="fa-solid fa-spinner fa-spin book-spinner"></i>
                 <span class="book-title"></span>
                 </h1>
             </div>
@@ -89,7 +89,7 @@ function parser() {
             const href = link.getAttribute('href');
             const parentLi = link.parentNode;
             const checkmarkIcon = document.createElement('i');
-            checkmarkIcon.className = 'fa fa-check';
+            checkmarkIcon.className = 'fa-solid fa-check';
             parentLi.insertBefore(checkmarkIcon, link);
 
             if (visitedLinks[href]) {
@@ -131,7 +131,7 @@ function parser() {
             const prevPage = document.createElement('a');
             prevPage.className = 'navigation navigation-prev';
             prevPage.href = prev;
-            prevPage.innerHTML = "<i class='fa fa-chevron-left'></i>";
+            prevPage.innerHTML = "<i class='fa-solid fa-chevron-left'></i>";
             bookBody.appendChild(prevPage);
         }
 
@@ -140,7 +140,7 @@ function parser() {
             const nextPage = document.createElement('a');
             nextPage.className = 'navigation navigation-next';
             nextPage.href = next;
-            nextPage.innerHTML = "<i class='fa fa-chevron-right'></i>";
+            nextPage.innerHTML = "<i class='fa-solid fa-chevron-right'></i>";
             bookBody.appendChild(nextPage);
         }
     };
@@ -248,7 +248,7 @@ function parser() {
             const id = el.getAttribute('id');
             if (id) {
                 const icon = document.createElement('i');
-                icon.className = 'fa fa-link';
+                icon.className = 'fa-solid fa-link';
                 const a = document.createElement('a');
                 a.className = 'header-link';
                 a.setAttribute('href', '#' + id);


### PR DESCRIPTION
- Remove deprecated polyfill.io CDN (security concern, unnecessary for MathJax 4)
- Upgrade FontAwesome from 4.7.0 to 6.5.1
- Update icon class syntax from 'fa fa-*' to 'fa-solid fa-*'
- Changed icons: bars, spinner, check, chevron-left/right, link