### PR TITLE
Fix left navigation bar loading issue

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -40,8 +40,8 @@
     <script type="text/javascript">
         window.Book = {
             'url': '{{ site.github.repository_url }}',
-            'rootUrl': '{{ site.github.url }}',
-            'toc': {'url': '{{ site.github.url }}/SUMMARY.html'},
+            'rootUrl': '{{ site.url }}{{ site.baseurl }}',
+            'toc': {'url': '{{ site.url }}{{ site.baseurl }}/SUMMARY.html'},
         };
     </script>
 


### PR DESCRIPTION
The TOC URL was using site.github.url which returns the root GitHub Pages URL without the baseurl path. This caused the navigation to try fetching SUMMARY.html from the wrong location (/SUMMARY.html instead of /physics-book/SUMMARY.html).

Changed to use site.url + site.baseurl which correctly resolves to the full site path where the SUMMARY.html file is located.