### PR TITLE
Fix MathJax equation rendering with async loading

### DIFF
--- a/assets/js/book-viewer.js
+++ b/assets/js/book-viewer.js
@@ -257,11 +257,18 @@ function parser() {
             }
         });
 
-        if (typeof MathJax.startup !== "undefined" && MathJax.startup !== null) {
-            MathJax.startup.promise = MathJax.startup.promise
-                .then(() => MathJax.typesetPromise([els]))
-                .catch((err) => console.log('Typeset failed: ' + err.message));
-        }
+        // Wait for MathJax to be ready, then typeset the content
+        const typesetMath = () => {
+            if (typeof MathJax !== "undefined" && MathJax.startup && MathJax.startup.promise) {
+                MathJax.startup.promise = MathJax.startup.promise
+                    .then(() => MathJax.typesetPromise([els]))
+                    .catch((err) => console.log('Typeset failed: ' + err.message));
+            } else {
+                // MathJax not loaded yet, wait and retry
+                setTimeout(typesetMath, 100);
+            }
+        };
+        typesetMath();
     };
 
     /**


### PR DESCRIPTION
The previous code checked MathJax.startup synchronously, but MathJax loads with async defer. If MathJax hadn't loaded when book-viewer.js ran, the check would fail silently and equations would never be typeset.

Now the code retries every 100ms until MathJax is ready, ensuring equations are always rendered regardless of script loading order.