### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,5 +1,8 @@
 name: Check Links
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main, gh-pages ]
@@ -47,6 +50,9 @@ jobs:
         retention-days: 7
 
   check-external-links:
+    permissions:
+      contents: read
+      issues: write
     runs-on: ubuntu-latest
     timeout-minutes: 45
     # Run external link check less frequently to avoid rate limiting


### PR DESCRIPTION
Potential fix for [https://github.com/veillette/physics-book/security/code-scanning/4](https://github.com/veillette/physics-book/security/code-scanning/4)

To fix this issue, we should explicitly set the `permissions` key in the workflow. This can be established either at the root (applying to all jobs) or per job. For this workflow:

- The majority of actions only require `contents: read`.
- The `check-external-links` job uses the `actions/github-script` action to create issues. For this action to create issues, the job needs `issues: write` and `contents: read`.
- The `check-links` job does not require write permissions; only `contents: read` is necessary.

Thus, the ideal approach is:
- Set `permissions: contents: read` at the workflow root to provide minimal privilege by default.
- Override in `check-external-links` job, specifying `permissions: contents: read, issues: write` for the single job that needs to create issues.

This is done by inserting the `permissions:` block at the top (for the workflow) and a job-specific override in the specific job needing write access to issues. No additional imports or dependencies are needed, only YAML edits to the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
