### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting function

### DIFF
--- a/assets/js/book-config.js
+++ b/assets/js/book-config.js
@@ -18,6 +18,8 @@ mergeObjectsRecursive(BookConfig, window.Book);
 
 function mergeObjectsRecursive(target, source) {
     for (const key in source) {
+        // Prevent prototype pollution by blocking dangerous keys
+        if (key === "__proto__" || key === "prototype" || key === "constructor") continue;
         if (source.hasOwnProperty(key)) {
             if (source[key] instanceof Object) {
                 if (!target[key]) {


### PR DESCRIPTION
Potential fix for [https://github.com/veillette/physics-book/security/code-scanning/1](https://github.com/veillette/physics-book/security/code-scanning/1)

To fix the prototype pollution vulnerability, the `mergeObjectsRecursive` function should explicitly block dangerous property names (such as `__proto__`, `prototype`, and `constructor`) from being merged. This guard should appear near the top of the `for...in` loop, before any properties are checked or assigned. The filtering should be performed on every recursion, as attackers may attempt to inject polluted properties at any level of the object structure. No existing functionality needs to change outside of this guard, and the fix is limited to editing the function in `assets/js/book-config.js`. No extra methods or imports are needed; just an early-return `continue` for the dangerous property names is sufficient.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
