### PR TITLE
Configure MathJax to process kramdown's math output

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -59,7 +59,7 @@
                 ac: 'a_\\mathrm{c}',     // a_c
             },
             inlineMath: [              // start/end delimiter pairs for in-line math
-                ['$$', '$$'],
+                ['$', '$'],            // single $ for inline (kramdown converts $$ to $ in spans)
                 ['\\(', '\\)']
             ],
             displayMath: [             // start/end delimiter pairs for display math
@@ -67,6 +67,11 @@
                 ['\\[', '\\]']
             ],
         },
+        options: {
+            // Process math in elements with class 'kdmath' (kramdown's math wrapper)
+            processHtmlClass: 'kdmath|equation',
+            skipHtmlTags: ['script', 'noscript', 'style', 'textarea', 'pre', 'code']
+        }
     };
     </script>
     <script defer id="MathJax-script"


### PR DESCRIPTION
The previous fix didn't work because kramdown was still processing math delimiters and wrapping them in <span class="kdmath"> elements with single dollar signs, but MathJax wasn't configured to process these elements.

Changes:
- Changed inline math delimiter from '$$' to '$' to match kramdown's output
- Added 'processHtmlClass' option to tell MathJax to process elements with class 'kdmath' (kramdown's math wrapper) and 'equation' (display math)
- This allows MathJax to properly render both inline and display equations that have been pre-processed by kramdown

This should now work with kramdown's GFM parser while still using MathJax for the actual rendering.