### PR TITLE
Upgrade to MathJax 4

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -65,7 +65,7 @@
         }
     };
     </script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js"></script>
+    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@4/es5/tex-chtml.js"></script>
 
     <script type="text/javascript">
         window.Book = {


### PR DESCRIPTION
- Changed CDN URL from mathjax@3 to mathjax@4
- Kept the working configuration (no window prefix, proper delimiters)
- MathJax 4 is compatible with the existing config