### PR TITLE
Remove async attribute from MathJax 4 script tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -65,7 +65,7 @@
         }
     };
     </script>
-    <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@4/es5/tex-chtml.js"></script>
+    <script id="MathJax-script" src="https://cdn.jsdelivr.net/npm/mathjax@4/es5/tex-chtml.js"></script>
 
     <script type="text/javascript">
         window.Book = {


### PR DESCRIPTION
MathJax 4 with a pre-configured MathJax object should load synchronously, not asynchronously, to ensure the library properly detects and uses the configuration object. The async attribute can prevent proper initialization.