### PR TITLE
Remove unused GitBook CSS styles

### DIFF
--- a/assets/css/gitbook.css
+++ b/assets/css/gitbook.css
@@ -92,7 +92,6 @@ dfn {
 }
 
 hr {
-    -moz-box-sizing: content-box;
     box-sizing: content-box;
     height: 0;
 }
@@ -209,8 +208,6 @@ input[type="radio"] {
 
 input[type="search"] {
     -webkit-appearance: textfield;
-    -moz-box-sizing: content-box;
-    -webkit-box-sizing: content-box;
     box-sizing: content-box;
 }
 
@@ -238,8 +235,6 @@ table {
 *,
 *:before,
 *:after {
-    -webkit-box-sizing: border-box;
-    -moz-box-sizing: border-box;
     box-sizing: border-box;
 }
 
@@ -292,33 +287,6 @@ img {
     vertical-align: middle;
 }
 
-.img-responsive {
-    display: block;
-    max-width: 100%;
-    height: auto;
-}
-
-.img-rounded {
-    border-radius: 3px;
-}
-
-.img-thumbnail {
-    padding: 4px;
-    line-height: 1.428571429;
-    background-color: #fff;
-    border: 1px solid #ddd;
-    border-radius: 1px;
-    -webkit-transition: all 0.2s ease-in-out;
-    transition: all 0.2s ease-in-out;
-    display: inline-block;
-    max-width: 100%;
-    height: auto;
-}
-
-.img-circle {
-    border-radius: 50%;
-}
-
 hr {
     margin-top: 20px;
     margin-bottom: 20px;
@@ -326,32 +294,8 @@ hr {
     border-top: 1px solid #eeeeee;
 }
 
-.sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    margin: -1px;
-    padding: 0;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-    border: 0;
-}
-
 p {
     margin: 0 0 10px;
-}
-
-.lead {
-    margin-bottom: 20px;
-    font-size: 16px;
-    font-weight: 200;
-    line-height: 1.4;
-}
-
-@media (min-width: 768px) {
-    .lead {
-        font-size: 21px;
-    }
 }
 
 small {
@@ -362,34 +306,12 @@ cite {
     font-style: normal;
 }
 
-.text-muted {
-    color: #999999;
-}
-
-.text-left {
-    text-align: left;
-}
-
-.text-right {
-    text-align: right;
-}
-
-.text-center {
-    text-align: center;
-}
-
 h1,
 h2,
 h3,
 h4,
 h5,
-h6,
-.h1,
-.h2,
-.h3,
-.h4,
-.h5,
-.h6 {
+h6 {
     font-family: inherit;
     font-weight: 500;
     line-height: 1.1;
@@ -400,13 +322,7 @@ h2 small,
 h3 small,
 h4 small,
 h5 small,
-h6 small,
-.h1 small,
-.h2 small,
-.h3 small,
-.h4 small,
-.h5 small,
-.h6 small {
+h6 small {
     font-weight: normal;
     line-height: 1;
     color: #999999;
@@ -426,23 +342,19 @@ h6 {
     margin-bottom: 10px;
 }
 
-h1,
-.h1 {
+h1 {
     font-size: 36px;
 }
 
-h2,
-.h2 {
+h2 {
     font-size: 30px;
 }
 
-h3,
-.h3 {
+h3 {
     font-size: 24px;
 }
 
-h4,
-.h4 {
+h4 {
     font-size: 18px;
 }
 
@@ -465,7 +377,6 @@ h4,
     color: #555;
     font-size: 18px;
     cursor: pointer;
-    -webkit-transition: all 0.3s ease;
     transition: all 0.3s ease;
 }
 
@@ -501,7 +412,6 @@ h4,
     color: #c4cdd4;
     background: #fff;
     border-right: 1px solid rgba(0, 0, 0, 0.07);
-    -webkit-transition: all .5s ease;
     transition: all 0.5s ease;
 }
 
@@ -516,7 +426,6 @@ h4,
     list-style: none;
     margin: 0;
     padding: 60px 0 0 0;
-    -webkit-transition: top .5s ease;
     transition: top 0.5s ease;
 }
 
@@ -592,7 +501,6 @@ h4,
 }
 
 .book.without-animation .book-summary {
-    -webkit-transition: none !important;
     transition: none !important;
 }
 
@@ -612,7 +520,6 @@ h4,
     bottom: 0;
     color: #000;
     background: #fff;
-    -webkit-transition: left .5s ease;
     transition: left 0.5s ease;
 }
 
@@ -664,7 +571,6 @@ h4,
 }
 
 .book.without-animation .book-body {
-    -webkit-transition: none !important;
     transition: none !important;
 }
 
@@ -1052,82 +958,6 @@ h4,
     border-radius: 3px;
 }
 
-@-webkit-keyframes animate-loading {
-    from {
-        width: 0;
-    }
-}
-
-@keyframes animate-loading {
-    from {
-        width: 0;
-    }
-}
-
-.book .book-body .book-progress {
-    height: 0;
-    width: 100%;
-    position: relative;
-    background: #fff;
-    margin-bottom: 10px;
-}
-
-.book .book-body .book-progress .bar {
-    height: 2px;
-    position: static;
-    right: 0;
-    left: 250px;
-    top: 50px;
-    background: #fff;
-    border-radius: 5px;
-    overflow: hidden;
-}
-
-.book .book-body .book-progress .bar .inner {
-    height: 100%;
-    width: 0;
-    background: #3c3;
-    -webkit-animation: animate-loading 1s;
-    animation: animate-loading 1s;
-}
-
-.book .book-body .book-progress .bar .inner .in-inner {
-    height: 100%;
-    width: 50%;
-}
-
-.book .book-body .book-progress .chapters {
-    display: none;
-    position: absolute;
-    right: 36px;
-    left: 20px;
-    top: 7px;
-}
-
-.book .book-body .book-progress .chapters .chapter {
-    position: absolute;
-    width: 16px;
-    height: 16px;
-    border-radius: 16px;
-    background: #fff;
-    box-shadow: 0 0 1px #bbbbbb;
-}
-
-.book .book-body .book-progress .chapters .chapter.done {
-    background: #3c3;
-    box-shadow: none;
-}
-
-@media (max-width: 800px) {
-    .book .book-body .book-progress .chapters .chapter {
-        display: none;
-    }
-
-    .book .book-body .book-progress .chapters .chapter.new-chapter {
-        display: block;
-    }
-}
-
 
 .book .book-body .navigation {
     position: absolute;
@@ -1143,7 +973,6 @@ h4,
     font-size: 40px;
     color: rgba(0, 0, 0, 0.2);
     text-align: center;
-    -webkit-transition: all 350ms ease;
     transition: all 350ms ease;
 }
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -22,20 +22,6 @@ section.normal > .title {
     background-color: #ffd;
 }
 
-/* styles for tags page */
-.inline-list li {
-    list-style-type: none;
-    display: inline-block;
-}
-
-.inline-list li:not(:last-child):after {
-    content: ', ';
-}
-
-.list-entry li {
-    list-style-type: none;
-}
-
 .header-link {
     position: absolute;
     left: -1em;
@@ -52,10 +38,6 @@ h5:hover .header-link,
 h6:hover .header-link {
     opacity: 1;
     color: black !important;
-}
-
-.book .book-body .book-progress .bar {
-    height: 10px;
 }
 
 .book .book-body .page-wrapper .page-inner {


### PR DESCRIPTION
Cleaned up both gitbook.css and styles.css by removing redundant, unused CSS classes and sections:

gitbook.css (reduced from 1,198 to 1,027 lines - 171 lines removed):
- Removed unused Bootstrap-style utility classes (.img-rounded, .img-thumbnail, .img-circle, .img-responsive, .sr-only, .lead, .text-muted, .text-left, .text-right, .text-center)
- Removed unused heading utility classes (.h1, .h2, .h3, .h4, .h5, .h6)
- Removed entire book-progress section (progress bar and chapter markers - ~60 lines) that was never implemented
- Cleaned up redundant vendor prefixes (-moz-box-sizing, etc.)

styles.css (reduced from 523 to 504 lines - 19 lines removed):
- Removed unused .inline-list and .list-entry classes

All removed CSS was verified to be unused in the codebase via grep searches across HTML, JavaScript, and markdown files. This improves page load performance by reducing CSS file size by ~15%.