### PR TITLE
Update GitHub Actions for restructured scripts

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -38,7 +38,7 @@ jobs:
       run: npm run test:ci
 
     - name: Check for orphan files
-      run: npm run find-orphans
+      run: npm run check-orphans
 
     - name: Upload link check results (on failure)
       if: failure()


### PR DESCRIPTION
Updated the link-check.yml GitHub Actions workflow to use the correct npm script name 'check-orphans' instead of the outdated 'find-orphans'. This aligns with the current script structure after recent reorganization.