### PR TITLE
Remove unnecessary Jekyll plugins and pagination settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ gem "jekyll", "~> 4.4"
 
 # Jekyll plugins
 group :jekyll_plugins do
-  gem "jekyll-sitemap", "~> 1.4"
-  gem "jekyll-paginate", "~> 1.1"
   gem "jekyll-github-metadata", "~> 2.16"
 end
 

--- a/_config.yml
+++ b/_config.yml
@@ -22,15 +22,6 @@ kramdown:
   syntax_highlighter: rouge
   math_engine: null  # We use MathJax via CDN instead
 
-# Plugins
-plugins:
-  - jekyll-sitemap
-  - jekyll-paginate
-
-# Pagination (if needed)
-paginate: 10
-paginate_path: "/page:num/"
-
 # Default front matter
 defaults:
   - scope:


### PR DESCRIPTION
Removed jekyll-sitemap and jekyll-paginate plugins from both _config.yml
and Gemfile as they are not needed for this textbook site. The site does
not use pagination (no blog posts) and the sitemap plugin is not required.

Fixes #138