### PR TITLE
Update Gemfile.lock after bundle install

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,11 +82,8 @@ GEM
     jekyll-github-metadata (2.16.1)
       jekyll (>= 3.4, < 5.0)
       octokit (>= 4, < 7, != 4.4.0)
-    jekyll-paginate (1.1.0)
     jekyll-sass-converter (3.1.0)
       sass-embedded (~> 1.75)
-    jekyll-sitemap (1.4.0)
-      jekyll (>= 3.7, < 5.0)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     json (2.17.1)
@@ -179,8 +176,6 @@ PLATFORMS
 DEPENDENCIES
   jekyll (~> 4.4)
   jekyll-github-metadata (~> 2.16)
-  jekyll-paginate (~> 1.1)
-  jekyll-sitemap (~> 1.4)
   kramdown-parser-gfm (~> 1.1)
   tzinfo (>= 1, < 3)
   tzinfo-data


### PR DESCRIPTION
Remove unused Jekyll plugins (jekyll-paginate, jekyll-sitemap) from
lockfile to match current Gemfile dependencies.