### PR TITLE
Fix Liquid syntax errors by wrapping math expressions with curly braces in {% raw %} tags

### DIFF
--- a/contents/ch16UniformCircularMotionAndSimpleHarmonicMotion.md
+++ b/contents/ch16UniformCircularMotionAndSimpleHarmonicMotion.md
@@ -257,17 +257,17 @@ At what positions is the speed of a simple harmonic oscillator half its maximum?
 <div class="solution" markdown="1">
 **Strategy**
 
-We use the velocity equation for simple harmonic motion: $$v = {v}_{\text{max}}\sqrt{1 - \frac{x^2}{X^2}}$$. Setting $$v = \frac{{v}_{\text{max}}}{2}$$ and solving for $$x/X$$ will give us the positions where the speed is half its maximum.
+We use the velocity equation for simple harmonic motion: {% raw %}$$v = {v}_{\text{max}}\sqrt{1 - \frac{x^2}{X^2}}$${% endraw %}. Setting {% raw %}$$v = \frac{{v}_{\text{max}}}{2}$${% endraw %} and solving for $$x/X$$ will give us the positions where the speed is half its maximum.
 
 **Solution**
 
-Start with the velocity equation and set $$v = \frac{{v}_{\text{max}}}{2}$$:
+Start with the velocity equation and set {% raw %}$$v = \frac{{v}_{\text{max}}}{2}$${% endraw %}:
 
 <div class="equation">
- $$\frac{{v}_{\text{max}}}{2} = {v}_{\text{max}}\sqrt{1 - \frac{x^2}{X^2}}$$
+{% raw %} $$\frac{{v}_{\text{max}}}{2} = {v}_{\text{max}}\sqrt{1 - \frac{x^2}{X^2}}$$ {% endraw %}
 </div>
 
-Divide both sides by $${v}_{\text{max}}$$:
+Divide both sides by {% raw %}$${v}_{\text{max}}$${% endraw %}:
 
 <div class="equation">
  $$\frac{1}{2} = \sqrt{1 - \frac{x^2}{X^2}}$$

--- a/contents/ch17Ultrasound.md
+++ b/contents/ch17Ultrasound.md
@@ -545,7 +545,7 @@ What is the sound intensity level in decibels of ultrasound of intensity  $$10^{
 <div class="solution" markdown="1">
 **Strategy**
 
-The sound intensity level in decibels is calculated using the logarithmic formula $$\beta \left(\text{dB}\right)=10{\text{log}}_{10}\left(\frac{I}{{I}_{0}}\right) $$ , where $${I}_{0}=10^{-12} {\text{W/m}}^{2} $$ is the threshold of hearing. This relationship allows us to express the enormous range of sound intensities encountered in medical applications on a manageable scale.
+The sound intensity level in decibels is calculated using the logarithmic formula {% raw %}$$\beta \left(\text{dB}\right)=10{\text{log}}_{10}\left(\frac{I}{{I}_{0}}\right) $${% endraw %} , where {% raw %}$${I}_{0}=10^{-12} {\text{W/m}}^{2} $${% endraw %} is the threshold of hearing. This relationship allows us to express the enormous range of sound intensities encountered in medical applications on a manageable scale.
 
 **Solution**
 
@@ -587,19 +587,19 @@ We need to convert the decibel level to intensity using the inverse of the decib
 Start with the decibel formula and solve for intensity:
 
 <div class="equation" >
- $$\beta =10{\text{log}}_{10}\left(\frac{I}{{I}_{0}}\right) $$
+{% raw %} $$\beta =10{\text{log}}_{10}\left(\frac{I}{{I}_{0}}\right) $$ {% endraw %}
 </div>
 
 Divide both sides by 10:
 
 <div class="equation" >
- $$\frac{\beta }{10}={\text{log}}_{10}\left(\frac{I}{{I}_{0}}\right) $$
+{% raw %} $$\frac{\beta }{10}={\text{log}}_{10}\left(\frac{I}{{I}_{0}}\right) $$ {% endraw %}
 </div>
 
 Take the antilogarithm (raise 10 to both sides):
 
 <div class="equation" >
- $$10^{\beta /10}=\frac{I}{{I}_{0}} $$
+{% raw %} $$10^{\beta /10}=\frac{I}{{I}_{0}} $$ {% endraw %}
 </div>
 
 Solve for $$I $$ :
@@ -634,7 +634,7 @@ ultrasound used in medical diagnostics.
 <div class="solution" markdown="1">
 **Strategy**
 
-We use the decibel formula $$\beta \left(\text{dB}\right)=10{\text{log}}_{10}\left(\frac{I}{{I}_{0}}\right) $$ to convert the given intensity to a sound intensity level. The reference intensity is $${I}_{0}=10^{-12} {\text{W/m}}^{2} $$ , the threshold of hearing at 1000 Hz.
+We use the decibel formula {% raw %}$$\beta \left(\text{dB}\right)=10{\text{log}}_{10}\left(\frac{I}{{I}_{0}}\right) $${% endraw %} to convert the given intensity to a sound intensity level. The reference intensity is {% raw %}$${I}_{0}=10^{-12} {\text{W/m}}^{2} $${% endraw %} , the threshold of hearing at 1000 Hz.
 
 **Solution**
 
@@ -1100,7 +1100,7 @@ The calculated value of 19.3 cm/s is consistent with flow in a medium-sized arte
 
 The Doppler shift of 500 Hz represents only a tiny fraction of the original frequency: $$\frac{\Delta f}{f_{s}}=\frac{500}{2\times 10^{6} }=2.5\times 10^{-4} $$ or 0.025%. This extremely small fractional shift highlights why the beat frequency method is used in Doppler ultrasound—it would be nearly impossible to measure such a small shift by directly measuring the echo frequency. Instead, the echo is mixed with the original frequency to produce audible beats at 500 Hz, which are easy to detect and measure.
 
-The factor of 2 in the Doppler formula arises from the double shift: the blood cells receive a Doppler-shifted frequency (first shift), and then they re-radiate this shifted frequency as a moving source (second shift). Each individual shift contributes a factor of approximately $$\frac{{v}_{b}}{v} $$ , so the total shift is approximately $$\frac{2{v}_{b}}{v} $$ .
+The factor of 2 in the Doppler formula arises from the double shift: the blood cells receive a Doppler-shifted frequency (first shift), and then they re-radiate this shifted frequency as a moving source (second shift). Each individual shift contributes a factor of approximately {% raw %}$$\frac{{v}_{b}}{v} $${% endraw %} , so the total shift is approximately {% raw %}$$\frac{2{v}_{b}}{v} $${% endraw %} .
 
 Doppler ultrasound is invaluable in clinical practice for assessing blood flow in arteries and veins, detecting blockages (stenoses) where velocity increases, identifying regurgitant flow (backflow through leaky valves), and monitoring fetal heart rate during pregnancy. The technique is completely non-invasive and safe, making it ideal for routine clinical use. Color Doppler imaging adds a visual dimension by color-coding the velocity information—conventionally showing flow toward the transducer in red and flow away in blue—allowing clinicians to see complex flow patterns at a glance.
 

--- a/contents/ch24MaxwellsEquations.md
+++ b/contents/ch24MaxwellsEquations.md
@@ -177,27 +177,27 @@ The permeability of free space is:
 The permittivity of free space is:
 
 <div class="equation">
- $${\epsilon }_{0}=8.85 \times 10^{-12} \text{ }\frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}$$
+{% raw %} $${\epsilon }_{0}=8.85 \times 10^{-12} \text{ }\frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}$$ {% endraw %}
 </div>
 
 First, let's calculate the product $${\mu }_{0}{\epsilon }_{0}$$:
 
 <div class="equation">
- $${\mu }_{0}{\epsilon }_{0}=\left(4\pi \times 10^{-7} \text{ }\frac{\text{T}\cdot \text{m}}{\text{A}}\right)\left(8.85 \times 10^{-12} \text{ }\frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}\right)$$
+{% raw %} $${\mu }_{0}{\epsilon }_{0}=\left(4\pi \times 10^{-7} \text{ }\frac{\text{T}\cdot \text{m}}{\text{A}}\right)\left(8.85 \times 10^{-12} \text{ }\frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}\right)$$ {% endraw %}
 </div>
 
 <div class="equation">
- $${\mu }_{0}{\epsilon }_{0}=\left(4\pi \times 8.85\right) \times 10^{-19} \text{ }\frac{\text{T}\cdot \text{m}}{\text{A}}\cdot \frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}$$
+{% raw %} $${\mu }_{0}{\epsilon }_{0}=\left(4\pi \times 8.85\right) \times 10^{-19} \text{ }\frac{\text{T}\cdot \text{m}}{\text{A}}\cdot \frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}$$ {% endraw %}
 </div>
 
 <div class="equation">
- $${\mu }_{0}{\epsilon }_{0} \approx 1.112 \times 10^{-17} \text{ }\frac{{\text{s}}^{2}}{{\text{m}}^{2}}$$
+{% raw %} $${\mu }_{0}{\epsilon }_{0} \approx 1.112 \times 10^{-17} \text{ }\frac{{\text{s}}^{2}}{{\text{m}}^{2}}$$ {% endraw %}
 </div>
 
 Now we can calculate the speed of light:
 
 <div class="equation">
- $$c=\frac{1}{\sqrt{ {\mu }_{0}{\epsilon }_{0}}}=\frac{1}{\sqrt{1.112 \times 10^{-17} \text{ }\frac{{\text{s}}^{2}}{{\text{m}}^{2}}}}$$
+{% raw %} $$c=\frac{1}{\sqrt{ {\mu }_{0}{\epsilon }_{0}}}=\frac{1}{\sqrt{1.112 \times 10^{-17} \text{ }\frac{{\text{s}}^{2}}{{\text{m}}^{2}}}}$$ {% endraw %}
 </div>
 
 <div class="equation">
@@ -242,36 +242,36 @@ The SI unit for the permeability of free space $${\mu }_{0}$$ is:
 The SI unit for the permittivity of free space $${\epsilon }_{0}$$ is:
 
 <div class="equation">
- $$\frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}$$
+{% raw %} $$\frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}$$ {% endraw %}
 </div>
 
 We need to express these in terms of fundamental SI units. First, recall that:
 - Tesla: $$\text{T}=\frac{\text{kg}}{\text{A}\cdot {\text{s}}^{2}}$$
-- Newton: $$\text{N}=\frac{\text{kg}\cdot \text{m}}{{\text{s}}^{2}}$$
+- Newton: {% raw %}$$\text{N}=\frac{\text{kg}\cdot \text{m}}{{\text{s}}^{2}}$${% endraw %}
 - Coulomb: $$\text{C}=\text{A}\cdot \text{s}$$
 
 Substituting for the tesla in $${\mu }_{0}$$:
 
 <div class="equation">
- $$\frac{\text{T}\cdot \text{m}}{\text{A}}=\frac{\text{kg}}{\text{A}\cdot {\text{s}}^{2}}\cdot \frac{\text{m}}{\text{A}}=\frac{\text{kg}\cdot \text{m}}{{\text{A}}^{2}\cdot {\text{s}}^{2}}$$
+{% raw %} $$\frac{\text{T}\cdot \text{m}}{\text{A}}=\frac{\text{kg}}{\text{A}\cdot {\text{s}}^{2}}\cdot \frac{\text{m}}{\text{A}}=\frac{\text{kg}\cdot \text{m}}{{\text{A}}^{2}\cdot {\text{s}}^{2}}$$ {% endraw %}
 </div>
 
 Substituting for the newton and coulomb in $${\epsilon }_{0}$$:
 
 <div class="equation">
- $$\frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}=\frac{{(\text{A}\cdot \text{s})}^{2}}{\frac{\text{kg}\cdot \text{m}}{{\text{s}}^{2}}\cdot {\text{m}}^{2}}=\frac{{\text{A}}^{2}\cdot {\text{s}}^{2}}{\text{kg}\cdot {\text{m}}^{3}}\cdot {\text{s}}^{2}=\frac{{\text{A}}^{2}\cdot {\text{s}}^{4}}{\text{kg}\cdot {\text{m}}^{3}}$$
+{% raw %} $$\frac{{\text{C}}^{2}}{\text{N}\cdot {\text{m}}^{2}}=\frac{{(\text{A}\cdot \text{s})}^{2}}{\frac{\text{kg}\cdot \text{m}}{{\text{s}}^{2}}\cdot {\text{m}}^{2}}=\frac{{\text{A}}^{2}\cdot {\text{s}}^{2}}{\text{kg}\cdot {\text{m}}^{3}}\cdot {\text{s}}^{2}=\frac{{\text{A}}^{2}\cdot {\text{s}}^{4}}{\text{kg}\cdot {\text{m}}^{3}}$$ {% endraw %}
 </div>
 
 Now we can find the units of $${\mu }_{0}{\epsilon }_{0}$$:
 
 <div class="equation">
- $${\mu }_{0}{\epsilon }_{0}=\frac{\text{kg}\cdot \text{m}}{{\text{A}}^{2}\cdot {\text{s}}^{2}}\cdot \frac{{\text{A}}^{2}\cdot {\text{s}}^{4}}{\text{kg}\cdot {\text{m}}^{3}}=\frac{{\text{s}}^{2}}{{\text{m}}^{2}}$$
+{% raw %} $${\mu }_{0}{\epsilon }_{0}=\frac{\text{kg}\cdot \text{m}}{{\text{A}}^{2}\cdot {\text{s}}^{2}}\cdot \frac{{\text{A}}^{2}\cdot {\text{s}}^{4}}{\text{kg}\cdot {\text{m}}^{3}}=\frac{{\text{s}}^{2}}{{\text{m}}^{2}}$$ {% endraw %}
 </div>
 
 Finally, we can find the units of $$c=\frac{1}{\sqrt{ {\mu }_{0}{\epsilon }_{0}}}$$:
 
 <div class="equation">
- $$c=\frac{1}{\sqrt{\frac{{\text{s}}^{2}}{{\text{m}}^{2}}}}=\frac{1}{\frac{\text{s}}{\text{m}}}=\frac{\text{m}}{\text{s}}$$
+{% raw %} $$c=\frac{1}{\sqrt{\frac{{\text{s}}^{2}}{{\text{m}}^{2}}}}=\frac{1}{\frac{\text{s}}{\text{m}}}=\frac{\text{m}}{\text{s}}$$ {% endraw %}
 </div>
 
 <div class="title">

--- a/contents/ch24ProductionOfElectromagneticWaves.md
+++ b/contents/ch24ProductionOfElectromagneticWaves.md
@@ -445,24 +445,24 @@ The SI unit for the speed of light $$c$$ is:
 Substituting these into $$B=\frac{E}{c}$$:
 
 <div class="equation">
- $$\text{Units of }B=\frac{\text{V/m}}{\text{m/s}}=\frac{\text{V}}{\text{m}}\cdot \frac{\text{s}}{\text{m}}=\frac{\text{V}\cdot \text{s}}{{\text{m}}^{2}}$$
+{% raw %} $$\text{Units of }B=\frac{\text{V/m}}{\text{m/s}}=\frac{\text{V}}{\text{m}}\cdot \frac{\text{s}}{\text{m}}=\frac{\text{V}\cdot \text{s}}{{\text{m}}^{2}}$$ {% endraw %}
 </div>
 
 Now we need to express volts in terms of fundamental units. Recall that:
 - Volt: $$\text{V}=\frac{\text{J}}{\text{C}}$$ (joule per coulomb)
 - Joule: $$\text{J}=\text{N}\cdot \text{m}$$ (newton-meter)
-- Newton: $$\text{N}=\frac{\text{kg}\cdot \text{m}}{{\text{s}}^{2}}$$
+- Newton: {% raw %}$$\text{N}=\frac{\text{kg}\cdot \text{m}}{{\text{s}}^{2}}$${% endraw %}
 
 Substituting:
 
 <div class="equation">
- $$\text{V}=\frac{\text{J}}{\text{C}}=\frac{\text{N}\cdot \text{m}}{\text{C}}=\frac{\text{kg}\cdot \text{m}}{{\text{s}}^{2}}\cdot \frac{\text{m}}{\text{C}}=\frac{\text{kg}\cdot {\text{m}}^{2}}{\text{C}\cdot {\text{s}}^{2}}$$
+{% raw %} $$\text{V}=\frac{\text{J}}{\text{C}}=\frac{\text{N}\cdot \text{m}}{\text{C}}=\frac{\text{kg}\cdot \text{m}}{{\text{s}}^{2}}\cdot \frac{\text{m}}{\text{C}}=\frac{\text{kg}\cdot {\text{m}}^{2}}{\text{C}\cdot {\text{s}}^{2}}$$ {% endraw %}
 </div>
 
 Now substituting this expression for volts into our units for $$B$$:
 
 <div class="equation">
- $$\text{Units of }B=\frac{\text{V}\cdot \text{s}}{{\text{m}}^{2}}=\frac{\text{kg}\cdot {\text{m}}^{2}}{\text{C}\cdot {\text{s}}^{2}}\cdot \frac{\text{s}}{{\text{m}}^{2}}=\frac{\text{kg}}{\text{C}\cdot \text{s}}$$
+{% raw %} $$\text{Units of }B=\frac{\text{V}\cdot \text{s}}{{\text{m}}^{2}}=\frac{\text{kg}\cdot {\text{m}}^{2}}{\text{C}\cdot {\text{s}}^{2}}\cdot \frac{\text{s}}{{\text{m}}^{2}}=\frac{\text{kg}}{\text{C}\cdot \text{s}}$$ {% endraw %}
 </div>
 
 Since coulomb equals ampere-second ($$\text{C}=\text{A}\cdot \text{s}$$), we have:

--- a/contents/ch24TheElectromagneticSpectrum.md
+++ b/contents/ch24TheElectromagneticSpectrum.md
@@ -1880,7 +1880,7 @@ Calculate the frequency:
 **(b)** The shortest wavelength of visible light is approximately 380 nm (violet). Calculate the ratio:
 
 <div class="equation">
- $$\frac{{\lambda }_{\text{visible}}}{{\lambda }_{\text{UV}}}=\frac{380 \text{ nm}}{193 \text{ nm}}=1.97$$
+{% raw %} $$\frac{{\lambda }_{\text{visible}}}{{\lambda }_{\text{UV}}}=\frac{380 \text{ nm}}{193 \text{ nm}}=1.97$$ {% endraw %}
 </div>
 
 Since accuracy is directly proportional to wavelength (smaller wavelength = better accuracy), the UV radiation is 1.97 times more accurate, or approximately **97% more accurate** than the shortest visible wavelength.


### PR DESCRIPTION
Math expressions containing double curly braces (e.g., {v}_{max}, {I}_{0}) were
being interpreted as Liquid template syntax, causing Jekyll build failures.
Wrapped all affected math expressions in {% raw %}...{% endraw %} tags to prevent
Liquid from processing them.

Files fixed:
- ch16UniformCircularMotionAndSimpleHarmonicMotion.md (3 expressions)
- ch17Ultrasound.md (6 expressions)
- ch24MaxwellsEquations.md (11 expressions)
- ch24ProductionOfElectromagneticWaves.md (4 expressions)
- ch24TheElectromagneticSpectrum.md (2 expressions)