### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete string escaping or encoding

### DIFF
--- a/scripts/content.js
+++ b/scripts/content.js
@@ -208,7 +208,7 @@ class ContentProcessor {
 
     const unitsWithoutDegree = UNITS.filter(u => u !== '°' && u !== 'deg');
     const unitPattern = new RegExp(
-      `(\\d)(${unitsWithoutDegree.join('|').replace(/\//g, '\\/')})(?!\\w)`,
+      `(\\d)(${unitsWithoutDegree.map(escapeRegExp).join('|')})(?!\\w)`,
       'g'
     );
 


### PR DESCRIPTION
Potential fix for [https://github.com/veillette/physics-book/security/code-scanning/9](https://github.com/veillette/physics-book/security/code-scanning/9)

In general, to fix this class of problem, any time you interpolate arbitrary strings into a `RegExp` pattern, you should first escape all regex metacharacters in those strings, including backslash. This is typically done with a small helper like `escapeRegExp` that replaces any special character with an escaped version, or by using a well-tested library.

In this file, the best minimal fix is to apply the existing `escapeRegExp` helper (already defined at the top of `scripts/content.js`) to each unit before joining them into the regex. Instead of only escaping `/` via `.replace(/\//g, '\\/')`, map `unitsWithoutDegree` through `escapeRegExp` and then `join('|')`. This preserves current functionality while making the pattern robust to any special characters that might be added to `UNITS` in the future. Concretely, modify the line constructing `unitPattern` so that the second capture group uses `unitsWithoutDegree.map(escapeRegExp).join('|')` and remove the ad‑hoc `.replace(/\//g, '\\/')`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
