### PR TITLE
Fix incorrect npm script name in link-check workflow

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm run test:ci
 
       - name: Check for orphan files
-        run: npm run check-orphans
+        run: npm run check:orphans
 
       - name: Upload link check results (on failure)
         if: failure()


### PR DESCRIPTION
Changed 'npm run check-orphans' to 'npm run check:orphans' to match the actual script name defined in package.json. The script uses a colon, not a hyphen.