### PR TITLE
Update color scheme for regular mode with modern palette

### DIFF
--- a/assets/css/gitbook.css
+++ b/assets/css/gitbook.css
@@ -145,13 +145,13 @@ svg:not(:root) {
 
 figure {
   margin: 0;
-  border: solid #efefff;
+  border: solid #e0f2f1;
   border-width: 3px 2px 0 2px;
 }
 
 figcaption {
   margin: 0;
-  background-color: #efefff;
+  background-color: #e0f2f1;
   padding: 0.35em 0.625em 0.75em;
 }
 
@@ -245,7 +245,7 @@ body {
   font-family: 'Open Sans', 'Clear Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 12px;
   line-height: 1.428571429;
-  color: #333;
+  color: #1e293b;
   background-color: #ffffff;
 }
 
@@ -266,13 +266,13 @@ textarea {
 }
 
 a {
-  color: #428bca;
+  color: #0d9488;
   text-decoration: none;
 }
 
 a:hover,
 a:focus {
-  color: #2a6496;
+  color: #0f766e;
   text-decoration: underline;
 }
 
@@ -387,7 +387,7 @@ h4 {
 
 .book.with-summary > .toggle-summary {
   left: 260px;
-  background: #fafafa;
+  background: #f8fafc;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
 }
 
@@ -475,7 +475,7 @@ h4 {
 
 .book .book-summary ul.summary li.active > a,
 .book .book-summary ul.summary li a:hover {
-  color: #008cff;
+  color: #0d9488;
   background: transparent;
   text-decoration: none;
 }
@@ -611,7 +611,7 @@ h4 {
 }
 
 .book .book-body .page-wrapper .page-inner section.normal a {
-  color: #4183c4;
+  color: #0d9488;
 }
 
 .book .book-body .page-wrapper .page-inner section.normal a.absent {
@@ -650,7 +650,7 @@ h4 {
 
 .book .book-body .page-wrapper .page-inner section.normal h2 {
   font-size: 2em;
-  border-bottom: 1px solid #eeeeee;
+  border-bottom: 1px solid #e2e8f0;
 }
 
 .book .book-body .page-wrapper .page-inner section.normal h3 {
@@ -786,9 +786,9 @@ h4 {
 }
 
 .book .book-body .page-wrapper .page-inner section.normal blockquote {
-  border-left: 4px solid #ddd;
+  border-left: 4px solid #cbd5e1;
   padding: 0 15px;
-  color: #777777;
+  color: #64748b;
 }
 
 .book .book-body .page-wrapper .page-inner section.normal blockquote p {
@@ -809,26 +809,26 @@ h4 {
 }
 
 .book .book-body .page-wrapper .page-inner section.normal table tr {
-  border-top: 1px solid #ccc;
+  border-top: 1px solid #cbd5e1;
   background-color: white;
   margin: 0;
   padding: 0;
 }
 
 .book .book-body .page-wrapper .page-inner section.normal table tr:nth-child(2n) {
-  background-color: #f8f8f8;
+  background-color: #f8fafc;
 }
 
 .book .book-body .page-wrapper .page-inner section.normal table tr th {
   font-weight: bold;
-  border: 1px solid #ccc;
+  border: 1px solid #cbd5e1;
   text-align: left;
   margin: 0;
   padding: 6px 13px;
 }
 
 .book .book-body .page-wrapper .page-inner section.normal table tr td {
-  border: 1px solid #ccc;
+  border: 1px solid #cbd5e1;
   text-align: left;
   margin: 0;
   padding: 6px 13px;
@@ -856,7 +856,7 @@ h4 {
 }
 
 .book .book-body .page-wrapper .page-inner section.normal span.frame > span {
-  border: 1px solid #ddd;
+  border: 1px solid #e2e8f0;
   display: block;
   float: left;
   overflow: hidden;
@@ -943,8 +943,8 @@ h4 {
   margin: 0 2px;
   padding: 0 5px;
   white-space: nowrap;
-  border: 1px solid #eaeaea;
-  background-color: #f8f8f8;
+  border: 1px solid #e2e8f0;
+  background-color: #f8fafc;
   border-radius: 3px;
 }
 
@@ -1023,7 +1023,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #34495e;
+  background-color: #0d9488;
   color: white;
   border: none;
   border-radius: 6px;
@@ -1035,7 +1035,7 @@ body {
 }
 
 .book .book-body .dark-mode-toggle:hover {
-  background-color: #4a5f7f;
+  background-color: #0f766e;
   transform: scale(1.05);
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.25);
 }
@@ -1064,7 +1064,7 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #7f8c8d;
+  background-color: #64748b;
   color: white;
   border-radius: 6px;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
@@ -1075,7 +1075,7 @@ body {
 }
 
 .book .book-body .pdf-download-btn:hover {
-  background-color: #95a5a6;
+  background-color: #475569;
   transform: scale(1.05);
   box-shadow: 0 3px 8px rgba(0, 0, 0, 0.25);
   text-decoration: none;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -19,7 +19,7 @@ section.normal > .title {
 
 /* When the URL refers to in-page elements make them stand out a bit */
 :target {
-  background-color: #ffd;
+  background-color: #fef3c7;
 }
 
 .header-link {
@@ -37,7 +37,7 @@ h4:hover .header-link,
 h5:hover .header-link,
 h6:hover .header-link {
   opacity: 1;
-  color: black !important;
+  color: #0d9488 !important;
 }
 
 .book .book-body .page-wrapper .page-inner {
@@ -86,7 +86,7 @@ h6:hover .header-link {
 .abstract {
   margin: 30px 6rem 0 6rem;
   padding: 15px;
-  background-color: #f4f7ff;
+  background-color: #ecfdf5;
 }
 
 .abstract::before {
@@ -95,19 +95,19 @@ h6:hover .header-link {
   font-size: 1.8rem;
   text-transform: uppercase;
   letter-spacing: 1px;
-  color: #383a3c;
+  color: #0d9488;
   content: 'Learning Outcomes:';
 }
 
 .glossary {
   margin: 30px 2rem 0 6rem;
   padding: 10px 20px;
-  background-color: #cfd4dd;
+  background-color: #fef3c7;
 }
 
 .glossary-title {
   display: inline-block;
-  color: #2c2c2f;
+  color: #92400e;
   font-size: 1.5rem;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -130,13 +130,13 @@ h6:hover .header-link {
 .note {
   margin: 30px 6rem 0 6rem;
   padding: 15px;
-  background-color: #ededed;
+  background-color: #f0f9ff;
 }
 
 .note:not([data-label]).ui-has-child-title > header > .title,
 .note:not([data-label]).ui-has-child-title > .title {
   display: inline-block;
-  color: #555555;
+  color: #0369a1;
   font-size: 1.5rem;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -149,7 +149,7 @@ h6:hover .header-link {
 
 .note:not([data-label]):not(.ui-has-child-title)::before {
   display: inline-block;
-  color: #555555;
+  color: #0369a1;
   font-size: 1.5rem;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -159,7 +159,7 @@ h6:hover .header-link {
 .note[data-label=''].ui-has-child-title > header > .title,
 .note[data-label=''].ui-has-child-title > .title {
   display: inline-block;
-  color: #555555;
+  color: #0369a1;
   font-size: 1.5rem;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -167,7 +167,7 @@ h6:hover .header-link {
 
 .note[data-label='']:not(.ui-has-child-title)::before {
   display: inline-block;
-  color: #555555;
+  color: #0369a1;
   font-size: 1.5rem;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -176,7 +176,7 @@ h6:hover .header-link {
 .note[data-label]:not([data-label='']).ui-has-child-title > header > .title,
 .note[data-label]:not([data-label='']).ui-has-child-title > .title {
   display: inline-block;
-  color: #555555;
+  color: #0369a1;
   font-size: 1.5rem;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -189,7 +189,7 @@ h6:hover .header-link {
 
 .note[data-label]:not([data-label='']):not(.ui-has-child-title)::before {
   display: inline-block;
-  color: #555555;
+  color: #0369a1;
   font-size: 1.5rem;
   text-transform: uppercase;
   letter-spacing: 1px;
@@ -198,8 +198,8 @@ h6:hover .header-link {
 
 .book .book-body .page-wrapper .page-inner .note > section {
   padding: 5px 15px;
-  border-top: 1px solid #555555;
-  background-color: #ededed;
+  border-top: 1px solid #0369a1;
+  background-color: #f0f9ff;
 }
 
 .example {
@@ -212,8 +212,8 @@ h6:hover .header-link {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #00e2cf;
-  background-color: #00432f;
+  color: #ffffff;
+  background-color: #ea580c;
 }
 
 .example:not([data-label]).ui-has-child-title > header > .title::before {
@@ -224,8 +224,8 @@ h6:hover .header-link {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #ededed;
-  background-color: #555555;
+  color: #ffffff;
+  background-color: #ea580c;
   content: 'Example';
 }
 
@@ -233,24 +233,24 @@ h6:hover .header-link {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #ededed;
-  background-color: #555555;
+  color: #ffffff;
+  background-color: #ea580c;
 }
 
 .example[data-label='']:not(.ui-has-child-title)::before {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #ededed;
-  background-color: #555555;
+  color: #ffffff;
+  background-color: #ea580c;
 }
 
 .example[data-label]:not([data-label='']).ui-has-child-title > header > .title {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #ededed;
-  background-color: #555555;
+  color: #ffffff;
+  background-color: #ea580c;
 }
 
 .example[data-label]:not([data-label='']).ui-has-child-title > header > .title::before {
@@ -261,15 +261,15 @@ h6:hover .header-link {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #ededed;
-  background-color: #555555;
+  color: #ffffff;
+  background-color: #ea580c;
   content: attr(data-label);
 }
 
 .book .book-body .page-wrapper .page-inner .example > section {
   padding: 5px 15px;
-  border-top: 1px solid #555555;
-  background-color: #ededed;
+  border-top: 1px solid #ea580c;
+  background-color: #fef2f2;
 }
 
 .exercise {
@@ -284,8 +284,8 @@ h6:hover .header-link {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #ededed;
-  background-color: #555555;
+  color: #ffffff;
+  background-color: #7c3aed;
 }
 
 .exercise:not([data-label]).ui-has-child-title > header > .title::before {
@@ -296,8 +296,8 @@ h6:hover .header-link {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #92cbf8;
-  background-color: #2f316e;
+  color: #ffffff;
+  background-color: #7c3aed;
   content: 'Exercise ' counter(exercise);
 }
 
@@ -306,8 +306,8 @@ h6:hover .header-link {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #ededed;
-  background-color: #555555;
+  color: #ffffff;
+  background-color: #7c3aed;
 }
 
 .exercise[data-label='']:not(.ui-has-child-title)::before,
@@ -315,14 +315,14 @@ h6:hover .header-link {
   display: inline-block;
   padding: 0.1em 1em;
   font-weight: bold;
-  color: #ededed;
-  background-color: #555555;
+  color: #ffffff;
+  background-color: #7c3aed;
 }
 
 .book .book-body .page-wrapper .page-inner .exercise > section {
   padding: 5px 15px;
-  border-top: 1px solid #555555;
-  background-color: #ededed;
+  border-top: 1px solid #7c3aed;
+  background-color: #faf5ff;
 }
 
 .example .problem,
@@ -334,7 +334,7 @@ h6:hover .header-link {
 
 .example .solution,
 .exercise .solution {
-  border-top: 1px solid #555555;
+  border-top: 1px solid #cbd5e1;
 }
 
 .example .solution > .ui-toggle-wrapper,
@@ -385,7 +385,7 @@ h6:hover .header-link {
 .example[data-element-type='problems-exercises'] .solution::before,
 .exercise[data-element-type='problems-exercises'] .solution::before {
   font-weight: bold;
-  color: #555555;
+  color: #475569;
   text-transform: uppercase;
   letter-spacing: 1px;
 }
@@ -409,11 +409,11 @@ h6:hover .header-link {
 }
 
 .book.with-summary .toggle-summary {
-  background-color: #fafafa;
+  background-color: #f8fafc;
 }
 
 .book .book-summary {
-  background-color: #fafafa;
+  background-color: #f8fafc;
 }
 
 .book .book-summary ul.summary {
@@ -423,7 +423,7 @@ h6:hover .header-link {
 .book .book-summary ul.summary li.part {
   font-size: 130%;
   font-weight: bold;
-  color: black;
+  color: #1e293b;
   padding-left: 15px;
 }
 
@@ -460,7 +460,7 @@ h6:hover .header-link {
 
 .book .book-summary ul.summary li.chapter::before {
   content: counter(chapter) '. ';
-  color: black;
+  color: #0d9488;
   font-weight: bold;
   font-size: 120%;
   padding-left: 1em;
@@ -476,7 +476,7 @@ h6:hover .header-link {
 
 .book .book-summary ul.summary li.chapter > ol > li::before {
   content: counter(chapter) '.' counter(section) ' ';
-  color: black;
+  color: #0d9488;
   font-weight: bold;
   padding-left: 2em;
 }
@@ -487,7 +487,7 @@ h6:hover .header-link {
 
 .page-title {
   font-weight: bold;
-  color: #404098;
+  color: #7c3aed;
   text-transform: uppercase;
   letter-spacing: 1px;
 }
@@ -534,7 +534,7 @@ iframe {
 }
 
 .search-input:focus {
-  border-color: #3367d6;
+  border-color: #14b8a6;
 }
 
 .search-input::placeholder {
@@ -602,7 +602,7 @@ iframe {
 .search-result-title {
   font-size: 14px;
   font-weight: 600;
-  color: #3367d6;
+  color: #0d9488;
   margin-bottom: 4px;
   line-height: 1.4;
 }
@@ -619,7 +619,7 @@ iframe {
 }
 
 .search-result-link:hover .search-result-title {
-  color: #1a4db8;
+  color: #0f766e;
 }
 
 .search-message {
@@ -632,7 +632,7 @@ iframe {
 /* Highlight matched text */
 .search-result-title mark,
 .search-result-preview mark {
-  background-color: #fff59d;
+  background-color: #fef3c7;
   padding: 1px 2px;
   border-radius: 2px;
   font-weight: inherit;


### PR DESCRIPTION
- Replace blue accents with teal/turquoise (#0d9488, #14b8a6)
- Update example boxes to warm orange/coral (#ea580c)
- Update exercise boxes to purple (#7c3aed)
- Replace note backgrounds with light sky blue (#f0f9ff)
- Update abstract to light mint (#ecfdf5)
- Update glossary to light amber (#fef3c7)
- Update text colors to darker slate (#1e293b, #334155)
- Update borders and backgrounds to lighter warm grays
- Update dark mode toggle button color to match teal theme
- Update PDF download button to slate gray (#64748b)
- Update search UI with teal accents
- Update table and code block colors for consistency