### PR TITLE
Fix Liquid template syntax errors in math expressions

### DIFF
--- a/contents/ch16SuperpositionAndResonance.md
+++ b/contents/ch16SuperpositionAndResonance.md
@@ -438,14 +438,14 @@ Twin jet engines on an airplane are producing an average sound frequency of 4100
 
 **Strategy**
 
-We're given the average frequency $${f}_{\text{ave}}=\frac{{f}_{1}+{f}_{2}}{2}=4100$$ Hz and the beat frequency $${f}_{\text{B}}=|{f}_{1}-{f}_{2}|=0.500$$ Hz. We can use these two equations to solve for the two individual frequencies $${f}_{1}$$ and $${f}_{2}$$.
+We're given the average frequency {% raw %}$${f}_{\text{ave}}=\frac{{f}_{1}+{f}_{2}}{2}=4100$${% endraw %} Hz and the beat frequency $${f}_{\text{B}}=|{f}_{1}-{f}_{2}|=0.500$$ Hz. We can use these two equations to solve for the two individual frequencies $${f}_{1}$$ and $${f}_{2}$$.
 
 **Solution**
 
 From the average frequency:
 
 <div class="equation">
- $$\frac{{f}_{1}+{f}_{2}}{2}=4100$$
+ {% raw %}$$\frac{{f}_{1}+{f}_{2}}{2}=4100$${% endraw %}
 </div>
 
 <div class="equation">

--- a/contents/ch23ReactanceInductiveAndCapacitive.md
+++ b/contents/ch23ReactanceInductiveAndCapacitive.md
@@ -374,7 +374,7 @@ Given:
 Rearranging the inductive reactance equation:
 
 <div class="equation">
-$$f=\frac{{X}_{L}}{2\pi L}$$
+{% raw %}$$f=\frac{{X}_{L}}{2\pi L}$${% endraw %}
 </div>
 
 Substituting the values:
@@ -414,7 +414,7 @@ Given:
 Rearranging for $$L$$:
 
 <div class="equation">
-$$L=\frac{{X}_{L}}{2\pi f}$$
+{% raw %}$$L=\frac{{X}_{L}}{2\pi f}$${% endraw %}
 </div>
 
 Substituting the values:
@@ -521,7 +521,7 @@ This is a very low frequency (about 8 Hz), well below the range of common AC pow
 <div class="solution" markdown="1">
 **Strategy**
 
-(a) First calculate the inductive reactance using $${X}_{L}=2\pi fL$$, then find the current using $$I=\frac{V}{{X}_{L}}$$.
+(a) First calculate the inductive reactance using $${X}_{L}=2\pi fL$$, then find the current using {% raw %}$$I=\frac{V}{{X}_{L}}$${% endraw %}.
 (b) Repeat the calculation with the new frequency.
 
 **Solution**
@@ -540,7 +540,7 @@ $${X}_{L}=2\pi fL=2\pi (60.0 \text{ Hz})(0.500 \text{ H})=188 \text{ Ω}$$
 Now find the current:
 
 <div class="equation">
-$$I=\frac{V}{{X}_{L}}=\frac{480 \text{ V}}{188 \text{ Ω}}=2.55 \text{ A}$$
+{% raw %}$$I=\frac{V}{{X}_{L}}=\frac{480 \text{ V}}{188 \text{ Ω}}=2.55 \text{ A}$${% endraw %}
 </div>
 
 **(b)** At $$f = 100 \text{ kHz} = 1.00 \times 10^5 \text{ Hz}$$:
@@ -550,7 +550,7 @@ $${X}_{L}=2\pi fL=2\pi (1.00 \times 10^5 \text{ Hz})(0.500 \text{ H})=3.14 \time
 </div>
 
 <div class="equation">
-$$I=\frac{V}{{X}_{L}}=\frac{480 \text{ V}}{3.14 \times 10^5 \text{ Ω}}=1.53 \times 10^{-3} \text{ A}=1.53 \text{ mA}$$
+{% raw %}$$I=\frac{V}{{X}_{L}}=\frac{480 \text{ V}}{3.14 \times 10^5 \text{ Ω}}=1.53 \times 10^{-3} \text{ A}=1.53 \text{ mA}$${% endraw %}
 </div>
 
 **Discussion**
@@ -575,7 +575,7 @@ The inductor exhibits dramatically different behavior at the two frequencies. At
 <div class="solution" markdown="1">
 **Strategy**
 
-(a) Calculate the capacitive reactance using $${X}_{C}=\frac{1}{2\pi fC}$$, then find the current using $$I=\frac{V}{{X}_{C}}$$.
+(a) Calculate the capacitive reactance using $${X}_{C}=\frac{1}{2\pi fC}$$, then find the current using {% raw %}$$I=\frac{V}{{X}_{C}}$${% endraw %}.
 (b) Repeat the calculation with the new frequency.
 
 **Solution**
@@ -594,7 +594,7 @@ $${X}_{C}=\frac{1}{2\pi fC}=\frac{1}{2\pi (60.0 \text{ Hz})(0.250 \times 10^{-6}
 Now find the current:
 
 <div class="equation">
-$$I=\frac{V}{{X}_{C}}=\frac{480 \text{ V}}{1.06 \times 10^4 \text{ Ω}}=0.0453 \text{ A}=45.3 \text{ mA}$$
+{% raw %}$$I=\frac{V}{{X}_{C}}=\frac{480 \text{ V}}{1.06 \times 10^4 \text{ Ω}}=0.0453 \text{ A}=45.3 \text{ mA}$${% endraw %}
 </div>
 
 **(b)** At $$f = 25.0 \text{ kHz} = 2.50 \times 10^4 \text{ Hz}$$:
@@ -604,7 +604,7 @@ $${X}_{C}=\frac{1}{2\pi fC}=\frac{1}{2\pi (2.50 \times 10^4 \text{ Hz})(0.250 \t
 </div>
 
 <div class="equation">
-$$I=\frac{V}{{X}_{C}}=\frac{480 \text{ V}}{25.5 \text{ Ω}}=18.8 \text{ A}$$
+{% raw %}$$I=\frac{V}{{X}_{C}}=\frac{480 \text{ V}}{25.5 \text{ Ω}}=18.8 \text{ A}$${% endraw %}
 </div>
 
 **Discussion**
@@ -628,7 +628,7 @@ A 20.0 kHz, 16.0 V source connected to an inductor produces a 2.00 A current. Wh
 <div class="solution" markdown="1">
 **Strategy**
 
-First find the inductive reactance using $$I=\frac{V}{{X}_{L}}$$, then use $${X}_{L}=2\pi fL$$ to find the inductance.
+First find the inductive reactance using {% raw %}$$I=\frac{V}{{X}_{L}}$${% endraw %}, then use $${X}_{L}=2\pi fL$$ to find the inductance.
 
 **Solution**
 
@@ -646,7 +646,7 @@ $${X}_{L}=\frac{V}{I}=\frac{16.0 \text{ V}}{2.00 \text{ A}}=8.00 \text{ Ω}$$
 Now solve for inductance:
 
 <div class="equation">
-$$L=\frac{{X}_{L}}{2\pi f}=\frac{8.00 \text{ Ω}}{2\pi (2.00 \times 10^4 \text{ Hz})}=\frac{8.00}{1.26 \times 10^5}=6.37 \times 10^{-5} \text{ H}=63.7 \text{ µH}$$
+{% raw %}$$L=\frac{{X}_{L}}{2\pi f}=\frac{8.00 \text{ Ω}}{2\pi (2.00 \times 10^4 \text{ Hz})}=\frac{8.00}{1.26 \times 10^5}=6.37 \times 10^{-5} \text{ H}=63.7 \text{ µH}$${% endraw %}
 </div>
 
 **Discussion**
@@ -668,7 +668,7 @@ A 20.0 Hz, 16.0 V source produces a 2.00 mA current when connected to a capacito
 <div class="solution" markdown="1">
 **Strategy**
 
-First find the capacitive reactance using $$I=\frac{V}{{X}_{C}}$$, then use $${X}_{C}=\frac{1}{2\pi fC}$$ to find the capacitance.
+First find the capacitive reactance using {% raw %}$$I=\frac{V}{{X}_{C}}$${% endraw %}, then use $${X}_{C}=\frac{1}{2\pi fC}$$ to find the capacitance.
 
 **Solution**
 
@@ -721,7 +721,7 @@ This is a reasonable capacitance value, just under 1 microfarad. At the low freq
 Solving for inductance:
 
 <div class="equation">
-$$L=\frac{{X}_{L}}{2\pi f}=\frac{2.00 \times 10^3 \text{ Ω}}{2\pi (1.50 \times 10^4 \text{ Hz})}=\frac{2000}{9.42 \times 10^4}=0.0212 \text{ H}=21.2 \text{ mH}$$
+{% raw %}$$L=\frac{{X}_{L}}{2\pi f}=\frac{2.00 \times 10^3 \text{ Ω}}{2\pi (1.50 \times 10^4 \text{ Hz})}=\frac{2000}{9.42 \times 10^4}=0.0212 \text{ H}=21.2 \text{ mH}$${% endraw %}
 </div>
 
 **(b)** At $$f = 60.0 \text{ Hz}$$:
@@ -852,7 +852,7 @@ about this result? (c) Which assumption or premise is responsible?
 <div class="solution" markdown="1">
 **Strategy**
 
-(a) Find the capacitive reactance from $$I=\frac{V}{{X}_{C}}$$, then calculate the capacitance from $${X}_{C}=\frac{1}{2\pi fC}$$.
+(a) Find the capacitive reactance from {% raw %}$$I=\frac{V}{{X}_{C}}$${% endraw %}, then calculate the capacitance from $${X}_{C}=\frac{1}{2\pi fC}$$.
 (b) Evaluate whether the calculated capacitance is physically reasonable for an EEG application.
 (c) Identify which parameter is unreasonable.
 

--- a/contents/ch30ThePauliExclusionPrinciple.md
+++ b/contents/ch30ThePauliExclusionPrinciple.md
@@ -1022,7 +1022,7 @@ The Rydberg formula gives:
 For $${n}_{\text{f}}=1 $$ and $${n}_{\text{i}}=\infty $$ :
 
 <div class="equation" >
- $$\frac{1}{\lambda }=R\left(\frac{1}{{1}^{2}}-\frac{1}{{\infty }^{2}}\right)=R\left(1-0\right)=R $$
+ {% raw %}$$\frac{1}{\lambda }=R\left(\frac{1}{{1}^{2}}-\frac{1}{{\infty }^{2}}\right)=R\left(1-0\right)=R $${% endraw %}
 </div>
 With $$R= 1.097\times 10^{7} {\text{ m}}^{-1} $$ :
 
@@ -1034,7 +1034,7 @@ The observed wavelength is $$\lambda =91.0 \text{ nm} $$ , which is less than $$
 The velocity is:
 
 <div class="equation" >
- $$v=c\frac{\Delta \lambda }{{\lambda }_{0}}=c\frac{{\lambda }_{0}-\lambda }{{\lambda }_{0}}=\left( 3.00\times 10^{8} \text{ m/s}\right)\frac{91.16-91.0}{91.16} $$
+ {% raw %}$$v=c\frac{\Delta \lambda }{{\lambda }_{0}}=c\frac{{\lambda }_{0}-\lambda }{{\lambda }_{0}}=\left( 3.00\times 10^{8} \text{ m/s}\right)\frac{91.16-91.0}{91.16} $${% endraw %}
 </div>
 <div class="equation" >
  $$v=\left( 3.00\times 10^{8} \text{ m/s}\right)\left(0.00175\right)= 5.26\times 10^{5} \text{ m/s}=526 \text{ km/s} $$
@@ -1298,7 +1298,7 @@ Converting to eV:
 (b) Typical molecular binding energies range from about 1 eV to 10 eV. The ratio is:
 
 <div class="equation" >
- $$\frac{{E}_{\text{binding}}}{{E}_{\text{photon}}}\sim \frac{1 \text{ eV}}{ 4.14\times 10^{-7} \text{ eV}}\sim 2.4\times 10^{6} $$
+ {% raw %}$$\frac{{E}_{\text{binding}}}{{E}_{\text{photon}}}\sim \frac{1 \text{ eV}}{ 4.14\times 10^{-7} \text{ eV}}\sim 2.4\times 10^{6} $${% endraw %}
 </div>
 The MRI photon energy is about **2.4 million times smaller** than typical molecular binding energies.
 
@@ -1549,7 +1549,7 @@ The solar corona has temperatures of 1–2 million kelvin, hot enough to fully i
 For hydrogen-like ions, the wavelengths are modified by $$Z^2 $$ :
 
 <div class="equation" >
- $$\frac{1}{\lambda }={Z}^{2}R\left(\frac{1}{ {n}_{\text{f}}^{2}}-\frac{1}{ {n}_{\text{i}}^{2}}\right)={2}^{2}\left( 1.097\times 10^{7} {\text{ m}}^{-1}\right)\left(\frac{1}{{1}^{2}}-\frac{1}{{2}^{2}}\right) $$
+ {% raw %}$$\frac{1}{\lambda }={Z}^{2}R\left(\frac{1}{ {n}_{\text{f}}^{2}}-\frac{1}{ {n}_{\text{i}}^{2}}\right)={2}^{2}\left( 1.097\times 10^{7} {\text{ m}}^{-1}\right)\left(\frac{1}{{1}^{2}}-\frac{1}{{2}^{2}}\right) $${% endraw %}
 </div>
 <div class="equation" >
  $$\frac{1}{\lambda }=4\left( 1.097\times 10^{7}\right)\left(\frac{3}{4}\right)= 3.29\times 10^{7} {\text{ m}}^{-1} $$
@@ -1616,7 +1616,7 @@ Third Balmer line ( $$n=5 $$ to $$n=2 $$ ): $${\lambda }_{0}=434 \text{ nm} $$
 Since $${\lambda }_{\text{obs}}={\lambda }_{0}\left(1+\frac{v}{c}\right) $$ , we have:
 
 <div class="equation" >
- $$\frac{1}{{\lambda }_{\text{obs}}}=\frac{1}{{\lambda }_{0}\left(1+v/c\right)}=\frac{1}{1+v/c}\cdot \frac{1}{{\lambda }_{0}}=\frac{R}{1+v/c}\left(\frac{1}{ {n}_{\text{f}}^{2}}-\frac{1}{ {n}_{\text{i}}^{2}}\right) $$
+ {% raw %}$$\frac{1}{{\lambda }_{\text{obs}}}=\frac{1}{{\lambda }_{0}\left(1+v/c\right)}=\frac{1}{1+v/c}\cdot \frac{1}{{\lambda }_{0}}=\frac{R}{1+v/c}\left(\frac{1}{ {n}_{\text{f}}^{2}}-\frac{1}{ {n}_{\text{i}}^{2}}\right) $${% endraw %}
 </div>
 Therefore, the modified Rydberg constant is:
 


### PR DESCRIPTION
Wrapped LaTeX math expressions containing {{ patterns with {% raw %} tags
to prevent Jekyll Liquid templating conflicts. This fixes build errors where
Liquid was interpreting math notation as template variables.

Files modified:
- ch16SuperpositionAndResonance.md (2 fixes)
- ch23ReactanceInductiveAndCapacitive.md (13 fixes)
- ch30ThePauliExclusionPrinciple.md (5 fixes)

Total: 20 expressions wrapped with raw tags across 3 files.