### PR TITLE
Fix Liquid syntax errors in markdown files

### DIFF
--- a/contents/ch23Inductance.md
+++ b/contents/ch23Inductance.md
@@ -527,7 +527,7 @@ $${\text{emf}}_{2}=-M\frac{\Delta {I}_{1}}{\Delta t}$$
 Rearranging to solve for $$M$$:
 
 <div class="equation">
-$$M=\frac{{\text{emf}}_{2}}{\Delta {I}_{1}/\Delta t}$$
+{% raw %}$$M=\frac{{\text{emf}}_{2}}{\Delta {I}_{1}/\Delta t}$${% endraw %}
 </div>
 
 The units are:

--- a/contents/ch29PhotonMomentum.md
+++ b/contents/ch29PhotonMomentum.md
@@ -488,7 +488,7 @@ Photon energy:
 Ratio:
 
 <div class="equation">
- $$\frac{E_{\text{photon}}}{{\text{KE}}_e} = \frac{1.99 \times 10^{-17} \text{ J}}{2.41 \times 10^{-21} \text{ J}} = 8.26 \times 10^{3}$$
+ {% raw %}$$\frac{E_{\text{photon}}}{{\text{KE}}_e} = \frac{1.99 \times 10^{-17} \text{ J}}{2.41 \times 10^{-21} \text{ J}} = 8.26 \times 10^{3}$${% endraw %}
 </div>
 
 **Discussion**

--- a/contents/ch8CollisionsOfPointMassesInTwoDimensions.md
+++ b/contents/ch8CollisionsOfPointMassesInTwoDimensions.md
@@ -602,7 +602,7 @@ Solving for $$ v'_{\text{ball},y} $$:
 The final ball velocity magnitude is:
 
 <div class="equation">
- $$ v'_{\text{ball}} = \sqrt{{v'_{\text{ball},x}}^2 + {v'_{\text{ball},y}}^2} = \sqrt{(8.80)^2 + (-2.31)^2} = \sqrt{77.4 + 5.34} = 9.10 \ms $$
+ {% raw %}$$ v'_{\text{ball}} = \sqrt{{v'_{\text{ball},x}}^2 + {v'_{\text{ball},y}}^2} = \sqrt{(8.80)^2 + (-2.31)^2} = \sqrt{77.4 + 5.34} = 9.10 \ms $${% endraw %}
 </div>
 
 The direction is:


### PR DESCRIPTION
Wrap {{...}} patterns in {% raw %} tags to prevent Jekyll/Liquid from interpreting them as template variables.