### PR TITLE
Make left navigation bar width adjustable

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -76,6 +76,8 @@
 
   /* Layout */
   --sidebar-width: 250px;
+  --sidebar-min-width: 150px;
+  --sidebar-max-width: 500px;
   --page-max-width: 800px;
   --border-radius-sm: 3px;
   --border-radius-md: 4px;
@@ -539,6 +541,38 @@ h4 {
 
 .book.without-animation .book-summary {
   transition: none !important;
+}
+
+/* ==================== Sidebar Resize Handle ==================== */
+
+.book .book-summary .resize-handle {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  inline-size: 5px;
+  cursor: ew-resize;
+  background: transparent;
+  transition: background-color 0.2s ease;
+  z-index: 10;
+}
+
+.book .book-summary .resize-handle:hover,
+.book .book-summary .resize-handle.resizing {
+  background-color: var(--color-primary);
+}
+
+.book .book-summary .resize-handle::after {
+  content: '';
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: -2px;
+  inline-size: 9px;
+}
+
+@media (max-width: 600px) {
+  .book .book-summary .resize-handle {
+    display: none;
+  }
 }
 
 /* ==================== Book Body ==================== */
@@ -1624,6 +1658,11 @@ body.dark-mode .btn-link {
 
 body.dark-mode .btn-link:hover {
   background: var(--color-dark-bg-secondary) linear-gradient(to bottom, var(--color-dark-bg-secondary) 5%, var(--color-dark-bg-tertiary) 100%);
+}
+
+body.dark-mode .book .book-summary .resize-handle:hover,
+body.dark-mode .book .book-summary .resize-handle.resizing {
+  background-color: var(--color-dark-link);
 }
 
 /* End Gitbook CSS */

--- a/assets/js/book-viewer.js
+++ b/assets/js/book-viewer.js
@@ -60,6 +60,57 @@ function parser() {
     event.preventDefault();
   });
 
+  // Add resize handle to sidebar
+  const resizeHandle = document.createElement('div');
+  resizeHandle.className = 'resize-handle';
+  bookSummary.appendChild(resizeHandle);
+
+  // Load saved sidebar width from localStorage
+  const savedWidth = localStorage.getItem('sidebarWidth');
+  if (savedWidth) {
+    document.documentElement.style.setProperty('--sidebar-width', savedWidth + 'px');
+  }
+
+  // Sidebar resize functionality
+  let isResizing = false;
+  let startX = 0;
+  let startWidth = 0;
+
+  resizeHandle.addEventListener('mousedown', function (e) {
+    isResizing = true;
+    startX = e.clientX;
+    const computedStyle = getComputedStyle(document.documentElement);
+    startWidth = parseInt(computedStyle.getPropertyValue('--sidebar-width'));
+    resizeHandle.classList.add('resizing');
+    book.classList.add('without-animation');
+    e.preventDefault();
+  });
+
+  document.addEventListener('mousemove', function (e) {
+    if (!isResizing) return;
+
+    const delta = e.clientX - startX;
+    const newWidth = startWidth + delta;
+    const minWidth = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-min-width'));
+    const maxWidth = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-max-width'));
+
+    // Constrain width between min and max
+    const constrainedWidth = Math.max(minWidth, Math.min(maxWidth, newWidth));
+    document.documentElement.style.setProperty('--sidebar-width', constrainedWidth + 'px');
+  });
+
+  document.addEventListener('mouseup', function () {
+    if (isResizing) {
+      isResizing = false;
+      resizeHandle.classList.remove('resizing');
+      book.classList.remove('without-animation');
+
+      // Save the new width to localStorage
+      const currentWidth = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--sidebar-width'));
+      localStorage.setItem('sidebarWidth', currentWidth);
+    }
+  });
+
   /**
    * render the summary on the left-hand side of the page
    */


### PR DESCRIPTION
Implement a resizable left-hand navigation bar that users can adjust by dragging a handle on the right edge of the sidebar. The implementation includes:

- Added resize handle with hover visual feedback (teal highlight)
- Mouse drag functionality to adjust sidebar width
- Width constraints: min 150px, max 500px
- localStorage persistence to remember user's preferred width
- Dark mode support with appropriate styling
- Mobile responsiveness (resize disabled on small screens)
- Smooth visual feedback during resize with no-animation class

The resize handle appears as a 5px wide draggable area on the right edge of the sidebar, which highlights in teal on hover or during resize. The new width is automatically saved to localStorage and restored on page load.