### PR TITLE
Potential fix for code scanning alert no. 16: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/book-viewer.js
+++ b/assets/js/book-viewer.js
@@ -338,7 +338,7 @@ function parser() {
         titleText = titleText.replace(/\\\\/g, '\\');
         // Convert math delimiters
         titleText = titleText.replace(/\(\s+([^)]+?)\s+\)/g, '$$$1$$');
-        title.innerHTML = titleText;
+        title.textContent = titleText;
         figure.insertBefore(title, img);
       }
       figure.setAttribute('id', id);


### PR DESCRIPTION
Potential fix for [https://github.com/veillette/physics-book/security/code-scanning/16](https://github.com/veillette/physics-book/security/code-scanning/16)

Use text insertion instead of HTML insertion for untrusted DOM-derived values.

Best fix here (without changing broader behavior outside this snippet): in `assets/js/book-viewer.js`, replace `title.innerHTML = titleText;` with `title.textContent = titleText;` in the `data-title` handling block (around lines 334–342). This preserves displayed text (including converted backslashes/math delimiters as literal text for later renderers) while preventing the browser from parsing attacker-supplied HTML.

No new imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
